### PR TITLE
Add a framework tag for defining a build dependency

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -5,6 +5,7 @@
         <clobbers target="cordova.plugins.profile-image-crop" />
     </js-module>
     <platform name="android">
+        <framework src="com.android.support:appcompat-v7:+" />
         <config-file target="config.xml" parent="/*">
             <feature name="ProfileImageCrop">
                 <param name="android-package" value="com.lihau.picrop.ProfileImageCrop"/>


### PR DESCRIPTION
In Android, cordova-plugin-imagecrop uses appcompat-v7 (android.support.v7.app.AppCompatActivity).
However, there are no [`framework` tags](https://cordova.apache.org/docs/en/9.x/plugin_ref/spec.html#framework). So, gradle doesn't resolve the dependency for appcompat, it will cause compile errors (depending on minSdkVersion and other imported plugins).

